### PR TITLE
fix handing a newline characters in the subscribeReply string

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ botType=** 机器人类型 目前支持(gpt,echo,spark,qwen,gemini)例如botType
 9. 支持指令
 
 ### 指令支持
-1. /help：查看帮助\n
+1. /help：查看帮助
 2. /gpt：切换与GPT对话
 3. /spark：切换与星火对话
 4. /qwen：切换与通义千问对话


### PR DESCRIPTION
如题，增加了对订阅公众号的初始回复字符串的换行处理，否则就会尴尬如斯：

![ccc75b7791ae2e6b882f2e05f6dd15b](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/12ecdc85-ea47-403d-bdcb-bf796ac60e28)
