### PR TITLE
check config before switch bot

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -94,6 +94,9 @@ func (s SimpleChat) HandleMediaMsg(msg *message.MixMessage) string {
 }
 
 func SwitchUserBot(userId string, botType string) string {
+	if _, err := config.CheckBotConfig(botType); err != nil {
+		return err.Error()
+	}
 	db.SetValue(fmt.Sprintf("%v:%v", config.Bot_Type_Key, userId), botType, 0)
 	return config.GetBotWelcomeReply(botType)
 }


### PR DESCRIPTION
## Description
Check the config before switching bot. Otherwise if the bot is unavailable, it gets stuck.

## Related Issues

[#32 ](https://github.com/pwh-pwh/aiwechat-vercel/issues/32)