### PR TITLE
Feature max tokens config

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -177,6 +177,7 @@ func GetChatBot(botType string) BaseChat {
 			errMsg: err.Error(),
 		}
 	}
+	maxTokens = config.GetMaxTokens()
 
 	switch botType {
 	case config.Bot_Type_Gpt:
@@ -185,26 +186,30 @@ func GetChatBot(botType string) BaseChat {
 			url = "https://api.openai.com/v1/"
 		}
 		return &SimpleGptChat{
-			token:    config.GetGptToken(),
-			url:      url,
-			BaseChat: SimpleChat{},
+			token:      config.GetGptToken(),
+			url:        url,
+			maxTokens:  maxTokens,
+			BaseChat:   SimpleChat{},
 		}
 	case config.Bot_Type_Gemini:
 		return &GeminiChat{
-			BaseChat: SimpleChat{},
-			key:      config.GetGeminiKey(),
+			BaseChat:  SimpleChat{},
+			key:       config.GetGeminiKey(),
+			maxTokens: maxTokens,
 		}
 	case config.Bot_Type_Spark:
 		config, _ := config.GetSparkConfig()
 		return &SparkChat{
-			BaseChat: SimpleChat{},
-			Config:   config,
+			BaseChat:  SimpleChat{},
+			Config:    config,
+			maxTokens: maxTokens,
 		}
 	case config.Bot_Type_Qwen:
 		config, _ := config.GetQwenConfig()
 		return &QwenChat{
-			BaseChat: SimpleChat{},
-			Config:   config,
+			BaseChat:  SimpleChat{},
+			Config:    config,
+			maxTokens: maxTokens,
 		}
 	default:
 		return &Echo{}

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -177,7 +177,7 @@ func GetChatBot(botType string) BaseChat {
 			errMsg: err.Error(),
 		}
 	}
-	maxTokens = config.GetMaxTokens()
+	maxTokens := config.GetMaxTokens()
 
 	switch botType {
 	case config.Bot_Type_Gpt:

--- a/chat/gemini.go
+++ b/chat/gemini.go
@@ -15,8 +15,8 @@ const (
 
 type GeminiChat struct {
 	BaseChat
-	key        string
-	max_tokens int
+	key       string
+	maxTokens int
 }
 
 func (s *GeminiChat) toDbMsg(msg *genai.Content) db.Msg {

--- a/chat/gemini.go
+++ b/chat/gemini.go
@@ -15,7 +15,8 @@ const (
 
 type GeminiChat struct {
 	BaseChat
-	key string
+	key        string
+	max_tokens int
 }
 
 func (s *GeminiChat) toDbMsg(msg *genai.Content) db.Msg {
@@ -38,6 +39,9 @@ func (s *GeminiChat) chat(userId, msg string) string {
 	}
 	defer client.Close()
 	model := client.GenerativeModel("gemini-pro")
+	if s.maxTokens > 0 {
+		model.SetMaxOutputTokens(s.maxTokens)		// 参数设置方法参考：https://github.com/google/generative-ai-go
+	}
 	// Initialize the chat
 	cs := model.StartChat()
 	var msgs = GetMsgListWithDb(config.Bot_Type_Gemini, userId, &genai.Content{

--- a/chat/gemini.go
+++ b/chat/gemini.go
@@ -40,7 +40,7 @@ func (s *GeminiChat) chat(userId, msg string) string {
 	defer client.Close()
 	model := client.GenerativeModel("gemini-pro")
 	if s.maxTokens > 0 {
-		model.SetMaxOutputTokens(s.maxTokens)		// 参数设置方法参考：https://github.com/google/generative-ai-go
+		model.SetMaxOutputTokens(int32(s.maxTokens))		// 参数设置方法参考：https://github.com/google/generative-ai-go
 	}
 	// Initialize the chat
 	cs := model.StartChat()

--- a/chat/qwen.go
+++ b/chat/qwen.go
@@ -19,15 +19,31 @@ const (
 type QwenChat struct {
 	BaseChat
 	Config *config.QwenConfig
+	maxTokens int
 }
 
 type QwenRequest struct {
 	Model string `json:"model"`
 	Input Input  `json:"input"`
+	Parameters Parameters `json:"parameters"`
 }
 
 type Input struct {
 	Messages []QwenMessage `json:"messages"`
+}
+
+type Parameters struct {
+	result_format      string   `json:"result_format"`
+	seed               int      `json:"seed"`
+	max_tokens         int      `json:"max_tokens"`
+	top_p              float64  `json:"top_p"`
+	top_k              float64  `json:"top_k"`
+	repetition_penalty float64  `json:"repetition_penalty"`
+	temperature        float64  `json:"temperature"`
+	stop               string   `json:"stop"`
+	enable_search      bool     `json:"enable_search"`
+	incremental_output bool     `json:"incremental_output"`
+	tools              []string `json:"tools"`
 }
 
 type QwenMessage struct {
@@ -68,6 +84,10 @@ func (chat *QwenChat) chat(userId string, message string) (res string) {
 	qwenReq := QwenRequest{
 		Model: chat.Config.ModelVersion,
 		Input: Input{Messages: msgs},
+	}
+	// 如果设置了环境变量且合法，则增加maxTokens参数，否则不设置
+	if chat.maxTokens > 0 {
+		qwenReq.Parameters.max_tokens = chat.maxTokens   // 参数名称参考：https://help.aliyun.com/zh/dashscope/developer-reference/api-details
 	}
 
 	body, _ := sonic.Marshal(qwenReq)

--- a/chat/spark.go
+++ b/chat/spark.go
@@ -20,7 +20,8 @@ import (
 
 type SparkChat struct {
 	BaseChat
-	Config *config.SparkConfig
+	Config    *config.SparkConfig
+	maxTokens int
 }
 
 type SparkResponse struct {
@@ -179,6 +180,9 @@ func toMsgList(msgList []SparkMessage) []db.Msg {
 
 // 生成参数
 func generateRequestBody(appid string, domain string, messages []SparkMessage) map[string]interface{} { // 根据实际情况修改返回的数据结构和字段名
+	if chat.maxTokens == 0 {
+		chat.maxTokens := 2048 	// 默认值，参数说明参考 https://www.xfyun.cn/doc/spark/Web.html
+	}
 	data := map[string]interface{}{ // 根据实际情况修改返回的数据结构和字段名
 		"header": map[string]interface{}{ // 根据实际情况修改返回的数据结构和字段名
 			"app_id": appid, // 根据实际情况修改返回的数据结构和字段名
@@ -188,7 +192,7 @@ func generateRequestBody(appid string, domain string, messages []SparkMessage) m
 				"domain":      domain,       // 根据实际情况修改返回的数据结构和字段名
 				"temperature": float64(0.8), // 根据实际情况修改返回的数据结构和字段名
 				"top_k":       int64(6),     // 根据实际情况修改返回的数据结构和字段名
-				"max_tokens":  int64(2048),  // 根据实际情况修改返回的数据结构和字段名
+				"max_tokens":  int64(chat.maxTokens),  // 根据实际情况修改返回的数据结构和字段名
 				"auditing":    "default",    // 根据实际情况修改返回的数据结构和字段名
 			},
 		},

--- a/chat/spark.go
+++ b/chat/spark.go
@@ -90,7 +90,7 @@ func (chat *SparkChat) chat(userId string, message string) (res string) {
 	}, chat.toDbMsg, chat.toChatMsg)
 
 	go func() {
-		data := generateRequestBody(chat.Config.AppId, chat.Config.SparkDomainVersion, msgs)
+		data := generateRequestBody(chat.Config.AppId, chat.Config.SparkDomainVersion, msgs, chat.maxTokens)
 		conn.WriteJSON(data)
 	}()
 
@@ -179,9 +179,9 @@ func toMsgList(msgList []SparkMessage) []db.Msg {
 }
 
 // 生成参数
-func generateRequestBody(appid string, domain string, messages []SparkMessage) map[string]interface{} { // 根据实际情况修改返回的数据结构和字段名
-	if chat.maxTokens == 0 {
-		chat.maxTokens := 2048 	// 默认值，参数说明参考 https://www.xfyun.cn/doc/spark/Web.html
+func generateRequestBody(appid string, domain string, messages []SparkMessage, maxTokens int) map[string]interface{} { // 根据实际情况修改返回的数据结构和字段名
+	if maxTokens == 0 {
+		maxTokens = 2048 	// 默认值，参数说明参考 https://www.xfyun.cn/doc/spark/Web.html
 	}
 	data := map[string]interface{}{ // 根据实际情况修改返回的数据结构和字段名
 		"header": map[string]interface{}{ // 根据实际情况修改返回的数据结构和字段名
@@ -192,7 +192,7 @@ func generateRequestBody(appid string, domain string, messages []SparkMessage) m
 				"domain":      domain,       // 根据实际情况修改返回的数据结构和字段名
 				"temperature": float64(0.8), // 根据实际情况修改返回的数据结构和字段名
 				"top_k":       int64(6),     // 根据实际情况修改返回的数据结构和字段名
-				"max_tokens":  int64(chat.maxTokens),  // 根据实际情况修改返回的数据结构和字段名
+				"max_tokens":  int64(maxTokens),  // 根据实际情况修改返回的数据结构和字段名
 				"auditing":    "default",    // 根据实际情况修改返回的数据结构和字段名
 			},
 		},

--- a/conf/.env.sample
+++ b/conf/.env.sample
@@ -11,6 +11,10 @@ WX_HELP_REPLY=输入以下命令进行对话\n/help：查看帮助\n/gpt：与GP
 # redis config
 KV_URL=redis://localhost:6479/0
 
+# maxOutput config
+# 最大输出tokens, 可选项
+maxOutput=500 (选填)
+
 # spark config
 # 此次使用的是3.5，请根据实际情况填写
 sparkUrl=wss://spark-api.xf-yun.com/v3.5/chat

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"strconv"
 
 	"github.com/pwh-pwh/aiwechat-vercel/db"
 )
@@ -118,4 +119,14 @@ func GetUserBotType(userId string) (bot string) {
 		bot = GetBotType()
 	}
 	return
+}
+
+func GetMaxTokens() int {
+	// 不设置或者设置不合法，均返回0，模型将使用默认值或者不设置
+	maxTokensStr := os.Getenv("maxOutput")
+	maxTokens, err := strconv.Atoi(maxTokensStr)
+	if err != nil {
+		maxTokens := 0
+	}
+	return maxTokens
 }

--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ func GetMaxTokens() int {
 	maxTokensStr := os.Getenv("maxOutput")
 	maxTokens, err := strconv.Atoi(maxTokensStr)
 	if err != nil {
-		maxTokens := 0
+		return 0
 	}
 	return maxTokens
 }


### PR DESCRIPTION
鉴于微信回复有长度限制，现通过环境变量 maxOutput 来限制模型的最大输出。部署时如果不添加该环境变量，则与原程序功能保持一致。

下图中为设置maxOutput=50的极端条件，实际使用可以放宽为 500~1000，1汉字≈2token。选取合适值可以既约束模型输出内容，又能减少拒绝回复率。如果仍然发生截断，可以提示模型“继续”回复：

![image](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/f70ce86c-c355-4c0d-aef7-e789c365feef)
