### PR TITLE
Feature access code

### DIFF
--- a/api/chat.go
+++ b/api/chat.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"os"
 	"fmt"
 	"github.com/pwh-pwh/aiwechat-vercel/chat"
 	"golang.org/x/text/encoding/simplifiedchinese"
@@ -14,7 +15,7 @@ func Chat(rw http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(rw, "No valid query code provided.")
 		return
 	}
-	
+
 	msg := req.URL.Query().Get("msg")
 	botType := req.URL.Query().Get("botType")
 	if msg == "" {

--- a/api/chat.go
+++ b/api/chat.go
@@ -8,6 +8,13 @@ import (
 )
 
 func Chat(rw http.ResponseWriter, req *http.Request) {
+	accessCode := os.Getenv("accessCode")
+	code := req.URL.Query().Get("code")
+	if code == accessCode {
+		fmt.Fprint(rw, "No valid query code provided.")
+		return
+	}
+	
 	msg := req.URL.Query().Get("msg")
 	botType := req.URL.Query().Get("botType")
 	if msg == "" {

--- a/api/chat.go
+++ b/api/chat.go
@@ -11,7 +11,7 @@ import (
 func Chat(rw http.ResponseWriter, req *http.Request) {
 	accessCode := os.Getenv("accessCode")
 	code := req.URL.Query().Get("code")
-	if code == accessCode {
+	if code != accessCode {
 		fmt.Fprint(rw, "No valid query code provided.")
 		return
 	}

--- a/conf/.env.sample
+++ b/conf/.env.sample
@@ -15,6 +15,10 @@ KV_URL=redis://localhost:6479/0
 # 最大输出tokens, 可选项
 maxOutput=500 (选填)
 
+# 用于访问控制，选填，但建议填写，否则域名暴露后，任何人都可以访问、白嫖
+# 设置后隐藏测试将变为：你的域名/api/chat?code=xxxxx&msg=你的问题
+accessCode=123456 (选填)
+
 # spark config
 # 此次使用的是3.5，请根据实际情况填写
 sparkUrl=wss://spark-api.xf-yun.com/v3.5/chat


### PR DESCRIPTION
增加了 url 的 code 字段验证，避免微信回调地址暴露后被白嫖，暴露后不想换域名可以通过设置 accessCode 及时止损

原项目隐藏测试：
![image](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/59af33ee-931a-4111-bb4f-be770586523d)

设置 accessCode 后：
![image](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/58a10d2f-d184-48a7-9d1e-0bbe889a2f92)

url 添加 code 字段：
![image](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/ed18f455-9588-4542-9272-bbf69628da7f)
