### PR TITLE
Bugfix: necessary default value in qwen

### DIFF
--- a/chat/qwen.go
+++ b/chat/qwen.go
@@ -97,6 +97,8 @@ func (chat *QwenChat) chat(userId string, message string) (res string) {
 		qwenReq.Parameters.MaxTokens = chat.maxTokens // 参数名称参考：https://help.aliyun.com/zh/dashscope/developer-reference/api-details
 	}
 	qwenReq.Parameters.TopP = 0.8; // 通义千问要求top_p ∈ (0,1)
+	qwenReq.Parameters.RepetitionPenalty = 1.1; // 用于控制模型生成时的重复度，需要大于0。提高repetition_penalty时可以降低模型生成的重复度。1.0表示不做惩罚。默认为1.1。
+	qwenReq.Parameters.Temperature = 0.85; // 取值范围：[0, 2)，系统默认值0.85。不建议取值为0，无意义。
 
 	body, _ := sonic.Marshal(qwenReq)
 	req, err := http.NewRequest("POST", chat.Config.HostUrl, bytes.NewReader(body))

--- a/chat/qwen.go
+++ b/chat/qwen.go
@@ -96,6 +96,7 @@ func (chat *QwenChat) chat(userId string, message string) (res string) {
 	if chat.maxTokens > 0 {
 		qwenReq.Parameters.MaxTokens = chat.maxTokens // 参数名称参考：https://help.aliyun.com/zh/dashscope/developer-reference/api-details
 	}
+	qwenReq.Parameters.TopP = 0.8; // 通义千问要求top_p ∈ (0,1)
 
 	body, _ := sonic.Marshal(qwenReq)
 	req, err := http.NewRequest("POST", chat.Config.HostUrl, bytes.NewReader(body))


### PR DESCRIPTION
增加了qwen模型的三个必要参数赋值（go默认初始值无法通过参数检查，top_p, repetition_penalty, temperature）
 [qwen入参描述参考](https://help.aliyun.com/zh/dashscope/developer-reference/token-api)

修改前：
![image](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/64adcf3b-e447-4c0a-a568-2e1291febfdd)

![image](https://github.com/pwh-pwh/aiwechat-vercel/assets/40236765/51b68614-c35a-40c8-87be-ceddbd5a7db4)

